### PR TITLE
毎朝5時に自動ビルド and デプロイ

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,14 @@
+name: Deploy
+
+on:
+  schedule:
+    - cron: '00 20 * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Hook build
+        run: curl -X POST -d '{}' $URL
+        env:
+          URL: ${{ secrets.NETLIFY_BUILD_HOOK_URL }}


### PR DESCRIPTION
build hook を github actions 経由で叩いて、毎日自動デプロイするようにしました。
https://docs.netlify.com/configure-builds/build-hooks/

おそらくマージ権限ないので、環境変数の設定とマージお願いします。

## 設定方法

下記から `NETLIFY_BUILD_HOOK_URL` を発行して、リポジトリのシークレットに追加する。

https://app.netlify.com/sites/your project id/settings/deploys#build-hooks

